### PR TITLE
Update to new version 3.7

### DIFF
--- a/Casks/beagleim.rb
+++ b/Casks/beagleim.rb
@@ -1,6 +1,6 @@
 cask 'beagleim' do
-  version '3.6'
-  sha256 'f8ebf241e4eb7953760dc3619393e338943bbe0139ce3b3a8a833592e911a7ef'
+  version '3.7'
+  sha256 'ed051bbdbdb549d2a45cb1e14e10b17b96eba6a6a72aa10d18873876884c3cf6'
 
   # github.com/tigase/beagle-im was verified as official when first introduced to the cask
   url "https://github.com/tigase/beagle-im/releases/download/#{version}/BeagleIM.#{version}.zip"
@@ -8,5 +8,5 @@ cask 'beagleim' do
   name 'Tigase BeagleIM'
   homepage 'https://beagle.im/'
 
-  app "BeagleIM #{version}.app"
+  app "BeagleIM.app"
 end


### PR DESCRIPTION
This pull should update version of BeagleIM in cask to 3.7