### PR TITLE
Updated beta to 4.0b100

### DIFF
--- a/Casks/beagleim-beta.rb
+++ b/Casks/beagleim-beta.rb
@@ -1,6 +1,6 @@
 cask 'beagleim-beta' do
-  version '4.0-b99'
-  sha256 '1b2503ef35b2d347ce63813c8ae3ffe8b4a04c87762edf26c847534fedb3b221'
+  version '4.0-b100'
+  sha256 '9bf9a16d3fff0425c86f379b2e153919f2316627443733ce60d2e64092329e89'
 
   # github.com/tigase/beagle-im was verified as official when first introduced to the cask
   url "https://github.com/tigase/beagle-im/releases/download/#{version}/BeagleIM.#{version}.zip"


### PR DESCRIPTION
I'm not sure if the sha256 is calculated properly as I've used:
`openssl dgst -sha256 filename`
instead of using `sha256sum` from homebrew.