### PR TITLE
Mark Beagle resource locations for `brew zap`

### DIFF
--- a/Casks/beagleim-beta.rb
+++ b/Casks/beagleim-beta.rb
@@ -9,4 +9,10 @@ cask 'beagleim-beta' do
   homepage 'https://beagle.im/'
 
   app "BeagleIM (beta).app"
+
+  zap trash: [
+    "~/Library/Saved Application State/org.tigase.messenger.BeagleIM.savedState",
+    "~/Library/Application Scripts/org.tigase.messenger.BeagleIM",
+    "~/Library/Containers/org.tigase.messenger.BeagleIM",
+  ]
 end

--- a/Casks/beagleim.rb
+++ b/Casks/beagleim.rb
@@ -9,4 +9,10 @@ cask 'beagleim' do
   homepage 'https://beagle.im/'
 
   app "BeagleIM.app"
+
+  zap trash: [
+    "~/Library/Saved Application State/org.tigase.messenger.BeagleIM.savedState",
+    "~/Library/Application Scripts/org.tigase.messenger.BeagleIM",
+    "~/Library/Containers/org.tigase.messenger.BeagleIM",
+  ]
 end


### PR DESCRIPTION
I don't know if I'm doing this right. I used [the Firefox `cask.rb`][ff] as an example and added the results of 

``` sh
find ~/Library -name '*[bB]eagle*' 2>/dev/null
find ~/Library -name '*tigase*' 2>/dev/null
```

If there are other paths, they can be added. If any of the stuff is common downloads (i.e. not person-specific), you can move those to a `rmdir` array alongside the `trash` one.

[ff]: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/firefox.rb