### PR TITLE
Remove `appcast` in favor of `livecheck`

### DIFF
--- a/Casks/beagleim-beta.rb
+++ b/Casks/beagleim-beta.rb
@@ -2,17 +2,21 @@ cask 'beagleim-beta' do
   version '5.3.5-b178'
   sha256 '9fe59d7e730fec9dae8e90c67f15bc20958f496c1ae1a8f1d801b1e22f262e3b'
 
-  # github.com/tigase/beagle-im was verified as official when first introduced to the cask
   url "https://github.com/tigase/beagle-im/releases/download/#{version}/BeagleIM.#{version}.zip"
-  appcast 'https://github.com/tigase/beagle-im/releases.atom'
   name 'Tigase BeagleIM beta'
   desc 'XMPP client based on TigaseSwift library'
   homepage 'https://beagle.im/'
 
+  livecheck do
+    url :url
+    regex(/^(?:BeagleIM )?v?(\d+\.\d+\.\d+-b\d+)$/i)
+    strategy :github_releases
+  end
+
   depends_on macos: ">= :catalina"
 
-  caveats "Beta version may be unstable and contain database schema changes which will make it impossible to rollback to older version. We suggest to copy `beagleim.sqlite` file using Finder to the safe location before starting a new beta version of BeagleIM."
-  
+  caveats "Beta versions may be unstable and contain database schema changes which cannot be rolled back to an older version. We suggest using Finder to copy the `beagleim.sqlite` file to a safe location before starting a new beta version of BeagleIM."
+
   app "BeagleIM (beta).app"
 
   zap trash: [

--- a/Casks/beagleim.rb
+++ b/Casks/beagleim.rb
@@ -2,12 +2,16 @@ cask 'beagleim' do
   version '5.3.4'
   sha256 'a9f454dc35d1638dc821f9dc3db51e6ebce5cdf32411ca86cf038d69528ae48e'
 
-  # github.com/tigase/beagle-im was verified as official when first introduced to the cask
   url "https://github.com/tigase/beagle-im/releases/download/#{version}/BeagleIM.#{version}.zip"
-  appcast 'https://github.com/tigase/beagle-im/releases.atom'
   name 'Tigase BeagleIM'
   desc 'XMPP client based on TigaseSwift library'
   homepage 'https://beagle.im/'
+
+  livecheck do
+    url :url
+    regex(/^(?:BeagleIM )?v?(\d+\.\d+\.\d+)$/i)
+    strategy :github_releases
+  end
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
Homebrew complains that `appcast` is deprecated.

I also tweaked the `caveat` phrasing and removed a meaningless comment.

Fixes #20