### PR TITLE
Don't skip prereleases for Beta livecheck

### DIFF
--- a/Casks/beagleim-beta.rb
+++ b/Casks/beagleim-beta.rb
@@ -9,8 +9,17 @@ cask 'beagleim-beta' do
 
   livecheck do
     url :url
-    regex(/^(?:BeagleIM )?v?(\d+\.\d+\.\d+-b\d+)$/i)
-    strategy :github_releases
+    regex(/^(\d+\.\d+\(?:.\d+)?-b\d+)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || !release["prerelease"]
+
+        match = json["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/beagleim.rb
+++ b/Casks/beagleim.rb
@@ -9,7 +9,6 @@ cask 'beagleim' do
 
   livecheck do
     url :url
-    regex(/^(?:BeagleIM )?v?(\d+\.\d+\.\d+)$/i)
     strategy :github_releases
   end
 


### PR DESCRIPTION
And the default regex works fine for release versions, so we don't need to have a special one.